### PR TITLE
Minor edit: Make the `<nav>` text visible on the linked pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,6 +7,6 @@
   <title>Semantic Container About Page</title>
 </head>
 <body>
-  This is the about page! Nothing goes here.  This exists for the <nav> portion of the lab.
+  This is the about page! Nothing goes here.  This exists for the <code>&lt;nav&gt;</code> portion of the lab.
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -7,7 +7,7 @@
   <title>Semantic Container Contact Page</title>
 </head>
 <body>
-  This is the contact page! Nothing goes here. This exists for the <nav> portion of the lab.
+  This is the contact page! Nothing goes here. This exists for the <code>&lt;nav&gt;</code> portion of the lab.
 
   Well, okay, here is a map:
 

--- a/products.html
+++ b/products.html
@@ -8,7 +8,7 @@
   </head>
   
   <body>
-    This is the products page! Nothing goes here.  This exists for the <nav> portion of the lab.
+    This is the products page! Nothing goes here.  This exists for the <code>&lt;nav&gt;</code> portion of the lab.
   </body>
   
 </html>


### PR DESCRIPTION
The `<nav>` part of the text in these pages was rendered as though it were actual HTML.
This changes it so that the word `<nav>` is displayed instead.